### PR TITLE
fix(fields): tzinfo is now optional a argument #9

### DIFF
--- a/sillyorm/fields.py
+++ b/sillyorm/fields.py
@@ -415,7 +415,7 @@ class Datetime(Field):
     sql_type = sql.SqlType.timestamp()
 
     def __init__(
-        self, tzinfo: datetime.tzinfo | None, required: bool = False, unique: bool = False
+        self, tzinfo: datetime.tzinfo = None, required: bool = False, unique: bool = False
     ) -> None:
         super().__init__(required=required, unique=unique)
         self.tzinfo = tzinfo


### PR DESCRIPTION
The `Datetime` field constructor required `tzinfo` as a positional argument, which contradicted both the docstring and expected behavior.

This commit makes `tzinfo` truly optional by providing a default value of `None`, allowing the field to be initialized as `Datetime()` without raising a `TypeError`.

Closes #9 

This aligns the implementation with the documentation: if `tzinfo` is omitted, the datetime is considered naive.